### PR TITLE
message_handler should return original handled when not handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ def message_handler(handled, message, context):
     # context is not set to NewDeckStats, so don't check for it
     # maybe Anki bug?
     if not message.startswith("Pokemanki#"):
-        return (False, None)
+        return handled
     if message == "Pokemanki#currentDeck":
         if f:
             html = tagmonDisplay().replace("`", "'")
@@ -115,7 +115,6 @@ def message_handler(handled, message, context):
         starts = "Pokemanki#search#"
         term = message[len(starts):]
         # Todo: implement selective
-        return (True, None)
     statsDialog.form.web.eval("Pokemanki.setPokemanki(`{}`)".format(html))
     return (True, None)
 


### PR DESCRIPTION
I've been seeing a lot of `unrecognized anki link:` logs in the terminal when testing my other addon, and it turned out that I've made a mistake here :sweat_smile:  This isn't anything critical though so please merge when you feel like it!