### PR TITLE
Prevent endless loop when no trades are available

### DIFF
--- a/trades.py
+++ b/trades.py
@@ -6,6 +6,7 @@ from datetime import date as dt
 
 from aqt.qt import *
 from aqt import mw
+from aqt.utils import showInfo
 
 from .utils import *
 
@@ -238,11 +239,8 @@ class Trades:
             self.newTrades()
             tradeData = get_json("_trades.json")
         if tradeData[1] == []:
-            notrademsg = QMessageBox()
-            notrademsg.setWindowTitle("Pokemanki")
-            notrademsg.setText(
-                "No trades are possible at the moment.")
-            notrademsg.exec()
+            showInfo(text="No trades are possible at the moment.", parent=mw,
+                     title="Pokémanki")
             return
         tradewindow = self.tradewindow
         tradewindow.setWindowTitle("Pokemanki")

--- a/trades.py
+++ b/trades.py
@@ -194,6 +194,7 @@ class Trades:
             elif len(possiblehaves) == 1:
                 have = possiblehaves[0]
             else:
+                i += 1
                 continue
             if have[0].startswith("Eevee") and want[0].startswith("Eevee"):
                 self.trades.append(
@@ -236,6 +237,13 @@ class Trades:
         else:
             self.newTrades()
             tradeData = get_json("_trades.json")
+        if tradeData[1] == []:
+            notrademsg = QMessageBox()
+            notrademsg.setWindowTitle("Pokemanki")
+            notrademsg.setText(
+                "No trades are possible at the moment.")
+            notrademsg.exec()
+            return
         tradewindow = self.tradewindow
         tradewindow.setWindowTitle("Pokemanki")
         tradewindow.setWindowModality(Qt.ApplicationModal)


### PR DESCRIPTION
That continue in the catchall else branch prevents increasing the iteration counter.